### PR TITLE
Secure all the things

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,0 +1,10 @@
+#image-0 { background-image: url(https://natnatnat.imgix.net/2018/wedding/0.jpg?auto=format,compress); }
+#image-5 { background-image: url(https://natnatnat.imgix.net/2018/wedding/5.jpg?auto=format,compress); }
+#image-4 { background-image: url(https://natnatnat.imgix.net/2018/wedding/4.jpg?auto=format,compress); }
+#image-3 { background-image: url(https://natnatnat.imgix.net/2018/wedding/3.jpg?auto=format,compress); }
+#image-6 { background-image: url(https://natnatnat.imgix.net/2018/wedding/6.jpg?auto=format,compress); }
+#image-12 { background-image: url(https://natnatnat.imgix.net/2018/wedding/12.jpg?auto=format,compress); }
+#image-7 { background-image: url(https://natnatnat.imgix.net/2018/wedding/7.jpg?auto=format,compress); }
+#image-9 { background-image: url(https://natnatnat.imgix.net/2018/wedding/9.jpg?auto=format,compress); }
+#image-10 { background-image: url(https://natnatnat.imgix.net/2018/wedding/10.jpg?auto=format,compress); }
+#image-11 { background-image: url(https://natnatnat.imgix.net/2018/wedding/11.jpg?auto=format,compress); }

--- a/index.html
+++ b/index.html
@@ -2,12 +2,13 @@
   <head>
     <title>Mel and Nat</title>
     <link rel="stylesheet" href="https://unpkg.com/tachyons@4.9.1/css/tachyons.min.css"/>
+    <link rel="stylesheet" href="css/main.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body class="">
     <main>
     <article class="bg-white">
-      <div class="vh-75 cover bg-center" style="background-image: url(https://natnatnat.imgix.net/2018/wedding/0.jpg?auto=format,compress);"></div>
+      <div class="vh-75 cover bg-center" id="image-0"></div>
       <div class="ph4 ph5-m ph6-l">
         <div class="pt5 f4 f2-ns measure center">
           <h1 class="fw6 f1 fl w-100 black-70 mt0 mb3 avenir">Mel and Nat!</h1>
@@ -32,13 +33,13 @@
       <div>
         <div class="cf mw8-ns w-100 center">
           <div class='fl w-100 w-33-l pr2-l mt4'>
-            <div class="pv7 pv6-l cover bg-center" style="background-image: url(https://natnatnat.imgix.net/2018/wedding/5.jpg?auto=format,compress);"></div>
+            <div class="pv7 pv6-l cover bg-center" id="image-5"></div>
           </div>
           <div class='fl w-100 w-33-l ph3-l mt4'>
-            <div class="pv7 pv6-l cover bg-center" style="background-image: url(https://natnatnat.imgix.net/2018/wedding/4.jpg?auto=format,compress);"></div>
+            <div class="pv7 pv6-l cover bg-center" id="image-4"></div>
           </div>
           <div class='fl w-100 w-33-l pl2-l mt4'>
-            <div class="pv7 pv6-l cover bg-center" style="background-image: url(https://natnatnat.imgix.net/2018/wedding/3.jpg?auto=format,compress);"></div>
+            <div class="pv7 pv6-l cover bg-center" id="image-3"></div>
           </div>
         </div>
       </div>
@@ -68,34 +69,28 @@
     </article>
     <section class="cf mt5 pv5 bt b--black-05 ph6-l">
       <a href="https://natnatnat.imgix.net/2018/wedding/6.jpg?auto=format,compress" class="fl w-third w-25-ns border-box overflow-hidden ba bw2 white" title="">
-        <div class="grow cover bg-center pv5 pv6-l" style="background-image:url(https://natnatnat.imgix.net/2018/wedding/6.jpg?auto=format,compress);"></div>
+        <div class="grow cover bg-center pv5 pv6-l" id="image-6"></div>
       </a>
       <a href="https://natnatnat.imgix.net/2018/wedding/12.jpg?auto=format,compress" class="fl w-third w-25-ns border-box overflow-hidden  ba bw2 white" title="">
-        <div class="grow cover bg-top pv5 pv6-l" style="background-image:url(https://natnatnat.imgix.net/2018/wedding/12.jpg?auto=format,compress);"></div>
+        <div class="grow cover bg-top pv5 pv6-l" id="image-12"></div>
       </a>
       <a href="https://natnatnat.imgix.net/2018/wedding/7.jpg?auto=format,compress" class="fl w-third w-25-ns border-box overflow-hidden ba bw2 white" title="">
-        <div class="grow cover bg-top pv5 pv6-l" style="background-image:url(https://natnatnat.imgix.net/2018/wedding/7.jpg?auto=format,compress);"></div>
+        <div class="grow cover bg-top pv5 pv6-l" id="image-7"></div>
       </a>
       <a href="https://natnatnat.imgix.net/2018/wedding/9.jpg?auto=format,compress" class="fl w-100 w-25-ns border-box overflow-hidden ba bw2 white" title="">
-        <div class="grow cover bg-top pv5 pv6-l" style="background-image:url(https://natnatnat.imgix.net/2018/wedding/9.jpg?auto=format,compress);"></div>
+        <div class="grow cover bg-top pv5 pv6-l" id="image-9"></div>
       </a>
       <a href="https://natnatnat.imgix.net/2018/wedding/10.jpg?auto=format,compress" class="fl w-50 border-box overflow-hidden ba bw2 white" title="">
-        <div class="grow cover bg-center pv5 pv7-l" style="background-image:url(https://natnatnat.imgix.net/2018/wedding/10.jpg?auto=format,compress);"></div>
+        <div class="grow cover bg-center pv5 pv7-l" id="image-10"></div>
       </a>
       <a href="https://natnatnat.imgix.net/2018/wedding/11.jpg?auto=format,compress" class="fl w-50 border-box overflow-hidden ba bw2 white" title="">
-        <div class="grow cover bg-center pv5 pv7-l" style="background-image:url(https://natnatnat.imgix.net/2018/wedding/11.jpg?auto=format,compress);"></div>
+        <div class="grow cover bg-center pv5 pv7-l" id="image-11"></div>
       </a>
     </section>
     </main>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-333449-20"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-333449-20');
-    </script>
+    <script src="js/main.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>Mel and Nat</title>
-    <link rel="stylesheet" href="https://unpkg.com/tachyons@4.9.1/css/tachyons.min.css"  integrity="sha384-QVMACRNcUWw6hYsjPb9VG4w1oUmXQDT+beNoCvCZYVr2vRM06khg+ShyPKVjLwnd" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://unpkg.com/tachyons@4.9.1/css/tachyons.min.css" integrity="sha384-QVMACRNcUWw6hYsjPb9VG4w1oUmXQDT+beNoCvCZYVr2vRM06khg+ShyPKVjLwnd" crossorigin="anonymous" />
     <link rel="stylesheet" href="css/main.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charset="utf-8" />

--- a/index.html
+++ b/index.html
@@ -1,9 +1,11 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <title>Mel and Nat</title>
-    <link rel="stylesheet" href="https://unpkg.com/tachyons@4.9.1/css/tachyons.min.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/tachyons@4.9.1/css/tachyons.min.css" />
     <link rel="stylesheet" href="css/main.css" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8" />
   </head>
   <body class="">
     <main>
@@ -58,12 +60,10 @@
         </div>
         <div class="measure f4 f3-ns center mv5 black-70">
           <h1 class="fw6 f3 avenir">Wedding Registries</h1>
-          <p class="lh-copy measure f3 black-70 baskerville">
-          <ul>
+          <ul class="lh-copy measure f3 black-70 baskerville">
             <li><a href="https://www.rei.com/lists/335641026">REI</a></li>
             <li><a href="https://www.crateandbarrel.com/gift-registry/melissa-cantrell-and-nathaniel-welch/r5690118">Crate and Barrel</a>
           </ul>
-          </p>
         </div>
       </div>
     </article>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <title>Mel and Nat</title>
-    <link rel="stylesheet" href="https://unpkg.com/tachyons@4.9.1/css/tachyons.min.css" />
+    <link rel="stylesheet" href="https://unpkg.com/tachyons@4.9.1/css/tachyons.min.css"  integrity="sha384-QVMACRNcUWw6hYsjPb9VG4w1oUmXQDT+beNoCvCZYVr2vRM06khg+ShyPKVjLwnd" crossorigin="anonymous" />
     <link rel="stylesheet" href="css/main.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charset="utf-8" />

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,5 @@
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'UA-333449-20');

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,7 +19,7 @@ server {
     add_header X-Frame-Options SAMEORIGIN;
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
-    add_header Content-Security-Policy "default-src 'none'; img-src 'self' https://natnatnat.imgix.net; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' https://unpkg.com; connect-src 'self' https://www.google-analytics.com;";
+    add_header Content-Security-Policy "default-src 'none'; img-src 'self' https://natnatnat.imgix.net https://www.google-analytics.com; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' https://unpkg.com; connect-src 'self' https://www.google-analytics.com; frame-ancestors 'none'; base-uri 'none'; form-action 'none';";
     add_header Referrer-Policy "no-referrer";
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,11 @@ server {
   server_tokens off;
   charset utf-8;
 
+  # Redirect HTTP requests to HTTPS.
+  if ($scheme != "https") {
+    return 301 https://$host$request_uri;
+  }
+
   location / {
     index  index.html index.htm;
 
@@ -14,5 +19,7 @@ server {
     add_header X-Frame-Options SAMEORIGIN;
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
+    add_header Content-Security-Policy "default-src 'none'; img-src 'self' https://natnatnat.imgix.net; script-src 'self' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' https://unpkg.com; connect-src 'self' https://www.google-analytics.com;";
+    add_header Referrer-Policy "no-referrer";
   }
 }


### PR DESCRIPTION
In an effort to improve the Mozilla Observatory score, I:

1. Added an HTTP-to-HTTPS redirect. **I wasn't able to get a test of this going in Google Cloud myself, so please do a test deploy of this somewhere else first!**
1. Moved all inline CSS and Javascript into external files (to avoid having to use `'unsafe-inline'` in the `Content-Security-Policy` header).
1. Added the `Content-Security-Policy` to severely limit what resources can be requested from where. (+35 points on the Observatory score!)
1. Added the `Referrer-Policy` header to squash `Referrer` headers.
1. Added a subresource integrity hash to the Tachyons CSS since it appears to be version-pinned and thus seems unlikely to change.

Unrelated to security, I also:

1. Added and modified some HTML tags to make it standard-compliant.
1. Fixed a `<ul>` wrapped in a `<p>`. The `<p>` was styled, but I don't think `<ul>` inherits styles from `<p>`. (I don't think `<ul>` is even allowed inside `<p>`.) I removed the `<p>` and moved the styling to the `<ul>`. **This changed the text's appearance, so please check that before deploy**, though I think it's now actually doing what you originally intended.