### PR TITLE
Pin nginx:alpine to nginx:1.29-alpine for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.29-alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 WORKDIR /usr/share/nginx/html
 EXPOSE 8080


### PR DESCRIPTION
## Problem

`FROM nginx:alpine` (without a version tag) is a non-reproducible base image. Two builds at different times may pull different nginx versions, which can silently introduce:

- Changed behaviour or breaking changes between nginx minor versions
- Different CVEs (a newer version might fix a known vulnerability, but the exact version is unpredictable)

## Fix

Pin to `nginx:1.29-alpine` (the current stable version at the time of this PR), matching the pattern already used in `locative.garden`.

## Testing

```bash
docker build -t melandnat .
docker run --rm -p 8080:8080 melandnat
```

## Audit notes

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile | `FROM nginx:alpine` unpinned | **Fixed (this PR)** |
| Static site | Pure HTML/CSS/JS, no dynamic content | No action needed |
